### PR TITLE
Synchronize with remote before upload-pack

### DIFF
--- a/main.go
+++ b/main.go
@@ -203,6 +203,12 @@ func (s *server) advertiseRefs(repo *repository, w http.ResponseWriter) {
 // but for caching purpose this reads all the client's request body
 // and then responds to it.
 func (s *server) uploadPack(repo *repository, w http.ResponseWriter, r io.ReadCloser) {
+	if err := s.synchronizeCache(repo); err != nil {
+		logger.Println(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
 	repo.RLock()
 	defer repo.RUnlock()
 


### PR DESCRIPTION
When multiple mir's are forming a Git-proxy cluster, there are chances that one server is receiving an upload-pack request based on ref advertising sent from another server.

Mir's currently synchronizing with remote only when ref advertising, this PR changes this behavior so that mir syncs on upload-pack request too.

closes #7 